### PR TITLE
Fix async to actually be async instead of concurrent

### DIFF
--- a/MagicHome.Example/GetStarted.cs
+++ b/MagicHome.Example/GetStarted.cs
@@ -9,19 +9,25 @@ namespace MagicHome.Example
     {
         static async Task Main()
         {
-            //Connect.
-            var light = new Light("192.168.1.2");
-            await light.ConnectAsync();
+            var discoveredLights = await Light.DiscoverAsync();
 
-            //Check if it is ON.
-            if(light.Power == false)
-                await light.TurnOnAsync();
+            if (discoveredLights?.Count > 0)
+            {
+                var light = discoveredLights[0];
 
-            //Change color to green.
-            await light.SetColorAsync(0, 255, 0);
+                //Connect.
+                await light.ConnectAsync();
 
-            //Print to console light's status.
-            Console.WriteLine(light.ToString());
+                //Check if it is ON.
+                if (light.Power == false)
+                    await light.TurnOnAsync();
+
+                //Change color to green.
+                await light.SetColorAsync(0, 255, 0);
+
+                //Print to console light's status.
+                Console.WriteLine(light.ToString());
+            }            
         }
     }
 }

--- a/MagicHome/Light.cs
+++ b/MagicHome/Light.cs
@@ -377,7 +377,7 @@ namespace MagicHome
         }
 
         /// <summary> Sends data to the light. </summary>
-        private Task SendDataAsync(params byte[] _data)
+        private async Task SendDataAsync(params byte[] _data)
         {
             List<byte> data = new List<byte>();
             data.AddRange(_data);
@@ -391,19 +391,16 @@ namespace MagicHome
                 data.Add(csum);
             }
 
-            return Task.Run(() => Socket.Send(data.ToArray()));
+            await Socket.SendAsync(new ArraySegment<byte>(data.ToArray()), SocketFlags.None);
         }
 
         /// <summary> Reads data from the light socket and returns it. </summary>
-        private Task<byte[]> ReadDataAsync()
+        private async Task<byte[]> ReadDataAsync()
         {
-            return Task.Run(() =>
-            {
-                byte[] buffer = new byte[14];
-                int receiver = Socket.Receive(buffer);
+            byte[] buffer = new byte[14];
+            await Socket.ReceiveAsync(new ArraySegment<byte>(buffer), SocketFlags.None);
 
-                return buffer;
-            });
+            return buffer;
         }
 
         public override string ToString() 

--- a/MagicHome/LightDiscovery.cs
+++ b/MagicHome/LightDiscovery.cs
@@ -46,7 +46,7 @@ namespace MagicHome
                     var socketReceiveTask = socket.ReceiveAsync();
                     socketReceiveTask.ConfigureAwait(false);
 
-                    var completedTask = await Task.WhenAny(socketReceiveTask, Task.Delay(1000, timeoutCancellationTokenSource.Token));
+                    var completedTask = await Task.WhenAny(socketReceiveTask, Task.Delay(Timeout, timeoutCancellationTokenSource.Token));
 
                     if (completedTask != socketReceiveTask)
                     {

--- a/MagicHome/LightDiscovery.cs
+++ b/MagicHome/LightDiscovery.cs
@@ -22,7 +22,6 @@ namespace MagicHome
         ///<summary>How long will the discovery take in milliseconds.</summary>
         public static int Timeout { get; set; } = 1000;
 
-        private static List<Light> Lights { get; set; } = new List<Light>();
         private static IPEndPoint ep = new IPEndPoint(IPAddress.Any, DISCOVERY_PORT);
         private static UdpClient socket = new UdpClient(DISCOVERY_PORT);
 
@@ -30,31 +29,47 @@ namespace MagicHome
         private const int DISCOVERY_PORT = 48899;
         private const string DISCOVERY_MESSAGE = "HF-A11ASSISTHREAD";
 
-        //This method is fired whenever we receive a response back.
-        private static void Receive(IAsyncResult result)
+        private static async Task<List<Light>> Send()
         {
-            byte[] data = socket.EndReceive(result, ref ep);
-            string message = Encoding.UTF8.GetString(data);
-
-            //Handle discovered address.
-            if (message != DISCOVERY_MESSAGE)
-            {
-                string address = message.Split(',')[0];
-                Lights.Add(new Light(address));
-            }
-
-            //Start receiving data once again.
-            socket.BeginReceive(Receive, new object());
-        }
-
-        private static void Send()
-        {
-            //Start receiving data.
-            socket.BeginReceive(Receive, new object());
+            List<Light> lights = new List<Light>();
 
             //Send discovery message.
             var data = Encoding.UTF8.GetBytes(DISCOVERY_MESSAGE);
-            socket.Send(data, data.Length, "255.255.255.255", DISCOVERY_PORT);
+            await socket.SendAsync(data, data.Length, "255.255.255.255", DISCOVERY_PORT);
+
+            bool keepReceiving = true;
+
+            while (keepReceiving)
+            {
+                using (var timeoutCancellationTokenSource = new CancellationTokenSource())
+                {
+                    var socketReceiveTask = socket.ReceiveAsync();
+                    socketReceiveTask.ConfigureAwait(false);
+
+                    var completedTask = await Task.WhenAny(socketReceiveTask, Task.Delay(1000, timeoutCancellationTokenSource.Token));
+
+                    if (completedTask != socketReceiveTask)
+                    {
+                        keepReceiving = false;
+                    }
+                    else
+                    {
+                        timeoutCancellationTokenSource.Cancel();
+                        var payload = await socketReceiveTask;
+
+                        string message = Encoding.UTF8.GetString(payload.Buffer);
+
+                        //Handle discovered address.
+                        if (message != DISCOVERY_MESSAGE)
+                        {
+                            string address = message.Split(',')[0];
+                            lights.Add(new Light(address));
+                        }
+                    }
+                }
+            }
+
+            return lights;
         }
 
         /// <summary>
@@ -64,10 +79,7 @@ namespace MagicHome
         /// <returns>A list of available lights.</returns>
         public static async Task<List<Light>> DiscoverAsync()
         {
-            Lights.Clear();
-            Send();
-            await Task.Delay(Timeout);
-            return Lights;
+            return await Send();
         }
     }
 }


### PR DESCRIPTION
In the latest changes made in the library, as seen for example in [this PR](https://github.com/nathanielxd/magic-home/pull/3), the execution model was changed from a synchronous to an asynchronous one.
However, the new situation created multiple issues - 

1. The new model wasn't pure async - it wasn't asynchronous at all in discovery and sends actually - When using `Task.Run((x => ...))` on a synchronous method (`Send`, `Receive` etc....) then the requested task is just queued to run in the background, another thread - but on that thread it actually runs synchronously.
In other words - if we currently have 2 active threads - the main thread and the background thread that runs the task - the background thread can only handle one task - the receive and send.

Bottom line - the code wasn't actually running asynchronously, but rather **concurrently** - and as as result each thread that was handling a send/receive task couldn't handle other things - which loses the point of `async` on single threads.

2. As a result of many `Task.Run(())` calls - as a result of what I wrote above - many threads would handle a single operation instead of being able to deal multiple operations/tasks. Utilization was not optimal.

3. Previously on discovery, we used begin receive which works in an event-based approach rather than a task-based approach - we send a request for discovery, and then wait for a result to arrive in the background, and when it does it goes to the function `Receive`. Instead, I allowed myself to run a `while` loop that keeps receiving messages from `MagicHome`, without using `BeginReceive` and `EndReceive`. When we stop receiving new devices for a whole 1 second (a time you defined yourselves), we stop waiting for a new response to arrive and finish our work. This also makes us not need to use `await Task.Sleep(1000)` which may in times make us face in race condition where 1000 milliseconds have passed, but the background task didn't synchronize the new `Lights` list to the task that called it.

4. If a consumer calls `DiscoverAsync` from more than one thread at the same time (concurrently) they may crash with an exception due to 2 Threads modifying the same variable (`Lights`) because it is static. So from now on, each `DiscoverAsync` creates its own `List` object and returns it, so no 2 tasks modify the same variable.

If you have any comments let me know, this has been tested using your `GetStarted` class. The code was also tested and based on modifications we made to your code and we now use in [RGBMaster](https://github.com/rgb-master-team/RGBMaster/tree/master/MagicHome).